### PR TITLE
feat: Double-sign L2 transactions (#22)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,5 +121,8 @@ dist
 # Vscode
 .vscode
 
+# idea
+.idea
+
 .DS_store
 */.DS_Store

--- a/src/api.ts
+++ b/src/api.ts
@@ -34,6 +34,7 @@ export const enum API_MAP {
   Search = 'GET /api/v1/search',
   SendRawCreateCollectionTx = 'POST /api/v1/tx/sendCreateCollectionTx',
   SendRawMintNftTx = 'POST /api/v1/tx/sendMintNftTx',
+  GetSignatureMessage = 'POST /api/v1/l2Signature',
   SendRawTx = 'POST /api/v1/sendTx',
 }
 
@@ -110,6 +111,7 @@ export interface IReqParmsMap {
   };
   [API_MAP.GetMaxOfferId]: { account_index: Zk.AccountIndex };
   [API_MAP.GetBlocks]: IReqBaseParam;
+  [API_MAP.GetSignatureMessage]: { tx_type: string; tx_info: string };
   [API_MAP.SendRawTx]: { tx_type: string; tx_info: string };
   [API_MAP.SendRawCreateCollectionTx]: { tx_info: string };
   [API_MAP.SendRawMintNftTx]: { tx_info: string };
@@ -159,6 +161,7 @@ export interface IResponseMap {
   [API_MAP.GetNextNonce]: { nonce: Zk.Nonce };
   [API_MAP.GetTxsByBlockHeight]: { txs: Zk.Tx[]; total: number };
   [API_MAP.GetMaxOfferId]: { offer_id: number };
+  [API_MAP.GetSignatureMessage]: { sign_body: string };
   [API_MAP.SendRawTx]: { tx_hash: string };
   [API_MAP.SendRawCreateCollectionTx]: { collection_id: number };
   [API_MAP.SendRawMintNftTx]: { nft_index: number };

--- a/src/client.ts
+++ b/src/client.ts
@@ -340,13 +340,30 @@ export class Client {
   }
 
   /**
-   * sends signed raw transaction and returns tx id
+   * get tx message that needs to be signed
+   * @param txType
+   * @param txInfo
    */
-  async sendRawTx(txType: string, txInfo: string) {
-    return this.http.req(API.API_MAP.SendRawTx, {
+  async getSignatureMessage(txType: string, txInfo: string) {
+    const body = await this.http.req(API.API_MAP.GetSignatureMessage, {
       tx_info: txInfo,
       tx_type: txType,
     });
+    return body.sign_body;
+  }
+
+  /**
+   * sends signed raw transaction and returns tx id
+   */
+  async sendRawTx(txType: string, txInfo: string, signature: string) {
+    return this.http.req(
+      API.API_MAP.SendRawTx,
+      {
+        tx_info: txInfo,
+        tx_type: txType,
+      },
+      signature
+    );
   }
 
   /**
@@ -368,12 +385,20 @@ export class Client {
     });
   }
 
+  /**
+   * @deprecated
+   * @param txInfo
+   */
   async sendRawCreateCollectionTx(txInfo: string) {
     return this.http.req(API.API_MAP.SendRawCreateCollectionTx, {
       tx_info: txInfo,
     });
   }
 
+  /**
+   * @deprecated
+   * @param txInfo
+   */
   async sendRawMintNftTx(txInfo: string) {
     return this.http.req(API.API_MAP.SendRawMintNftTx, {
       tx_info: txInfo,

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, AxiosResponse } from 'axios';
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import * as API from './api';
 
 export class Http {
@@ -10,20 +10,33 @@ export class Http {
     });
   }
 
-  async req<T extends API.URL_INFO>(api: T, params: API.IReqParmsMap[T]): Promise<API.IResponseMap[T]> {
+  async req<T extends API.URL_INFO>(
+    api: T,
+    params: API.IReqParmsMap[T],
+    signature?: string
+  ): Promise<API.IResponseMap[T]> {
     const [method, url] = api.split(' ') as ['GET' | 'POST', string];
 
     let response = { data: null };
+    const axiosRequestConfig: AxiosRequestConfig = signature
+      ? {
+          headers: {
+            Signature: signature,
+          },
+        }
+      : {};
 
     if (method === 'GET') {
       response = await this.client.get(url, {
         params,
+        ...axiosRequestConfig,
       });
     }
 
     if (method === 'POST') {
       response = await this.client.post(url, null, {
         params,
+        ...axiosRequestConfig,
       });
     }
 


### PR DESCRIPTION
## Description

Double-sign L2 transactions to fix the issue of L2 Seed being hacked by phishing

## Rationale

Get transaction signature plaintext by api and sign it to the signature by L1 private key, send each L2 tx with this signature by request header

## Changes

Notable changes:

* sendRawTx add signature parameter
* Add getSignatureMessage to get signature plaintext
